### PR TITLE
Do not change entries when you write them out if they were not modified.

### DIFF
--- a/SharpHostsFile/HostsFile.cs
+++ b/SharpHostsFile/HostsFile.cs
@@ -150,6 +150,9 @@ namespace SharpHostsFile
             }
         }
 
+        /// <summary>
+        /// </summary>
+        /// <param name="entries"></param>
         public void AddAll(IEnumerable<HostsFileEntryBase> entries)
         {
             foreach (var entry in entries)

--- a/SharpHostsFile/HostsFileComment.cs
+++ b/SharpHostsFile/HostsFileComment.cs
@@ -1,17 +1,10 @@
-﻿using System.Text.RegularExpressions;
-
-namespace SharpHostsFile
+﻿namespace SharpHostsFile
 {
     /// <summary>
     ///     Represents a hosts file comment entry.
     /// </summary>
     public class HostsFileComment : HostsFileEntryBase
     {
-        /// <summary>
-        ///     Pattern to match hosts file map comment.
-        /// </summary>
-        public static readonly Regex Pattern = new Regex(@"\s#\s*(?<comment>.*)", RegexOptions.Compiled);
-
         /// <summary>
         ///     Initializes a new instance of the SharpHostsFile.HostsFileComment class.
         /// </summary>
@@ -58,7 +51,7 @@ namespace SharpHostsFile
         /// <returns></returns>
         public override string ToString(bool preserveFormatting)
         {
-            return RegexHelper.ReplaceNamedGroup(RawLine, "comment", Comment, Pattern.Match(RawLine));
+            return preserveFormatting ? RawLine : Comment;
         }
 
         #endregion

--- a/SharpHostsFile/HostsFileMapEntry.cs
+++ b/SharpHostsFile/HostsFileMapEntry.cs
@@ -12,7 +12,7 @@ namespace SharpHostsFile
         /// <summary>
         ///     Pattern to match hosts file map entry.
         /// </summary>
-        public static readonly Regex Pattern = new Regex(@"^\s*(?<address>\S+)\s+(?<hostname>\S+)\s*($|#(?<comment>\S+))", RegexOptions.Compiled);
+        public static readonly Regex Pattern = new Regex(@"^\s*(?<address>\S+)\s+(?<hostname>\S+)\s*(\#\s*(?<comment>\S+))?$", RegexOptions.Compiled);
 
         /// <summary>
         ///     Initializes a new instance of the SharpHostsFile.HostsFileMapEntry class.
@@ -62,7 +62,7 @@ namespace SharpHostsFile
         /// <returns></returns>
         public override string ToString()
         {
-            return $"{Address} {Hostname}{(Comment != null ? $" {Comment}" : "")}";
+            return $"{Address} {Hostname}{(Comment != null ? $" # {Comment}" : "")}";
         }
 
         /// <summary>


### PR DESCRIPTION
If I read in \Windows\System32\drivers\etc\hosts, made no changes to the entries, and wrote the file back out, some entries were changed. An additional "#" would be added to a comment entry and any comment on a map entry would not be written out correctly. These changes ensure that entries are written out as they were read in.